### PR TITLE
fix: take dummy objects' height into calculation when locating their Z position

### DIFF
--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -359,7 +359,7 @@ void DummyPerceptionPublisherNode::objectCallback(
           ros_map2base_link = tf_buffer_.lookupTransform(
             "map", "base_link", rclcpp::Time(0), rclcpp::Duration::from_seconds(0.5));
           object.initial_state.pose_covariance.pose.position.z =
-            ros_map2base_link.transform.translation.z;
+            ros_map2base_link.transform.translation.z + 0.5*object.shape.dimensions.z;
         } catch (tf2::TransformException & ex) {
           RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "%s", ex.what());
           return;
@@ -406,7 +406,7 @@ void DummyPerceptionPublisherNode::objectCallback(
               ros_map2base_link = tf_buffer_.lookupTransform(
                 "map", "base_link", rclcpp::Time(0), rclcpp::Duration::from_seconds(0.5));
               objects_.at(i).initial_state.pose_covariance.pose.position.z =
-                ros_map2base_link.transform.translation.z;
+                ros_map2base_link.transform.translation.z + 0.5*objects_.at(i).shape.dimensions.z;
             } catch (tf2::TransformException & ex) {
               RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "%s", ex.what());
               return;


### PR DESCRIPTION

## Description

fix: take dummy objects' height into calculation when locating their Z position

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
